### PR TITLE
Add dev script with watch mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,6 @@ By default, the server runs on HTTP only. To enable HTTPS for development (usefu
    mv localhost+2*.pem cert/
    ```
 
-4. **Restart the server** - it will automatically detect the certificates and start both HTTP (port 3000) and HTTPS (port 3001) servers.
+4. **Restart the server** - certificate files aren't watched, so stop and rerun `pnpm run dev`. On startup, the server detects the certificates and starts both HTTP (port 3000) and HTTPS (port 3001) servers.
 
 The certificates are gitignored, so each developer needs to generate their own locally trusted certificates.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A minimal example of an MCP server endpoint using Express and Clerk for authenti
 - Run `pnpm i` to install dependencies.
 - Create a Clerk application, then toggle on the **Dynamic client registration** option in the [**OAuth applications**](https://dashboard.clerk.com/~/oauth-applications) page in the Clerk Dashboard.
 - Run `cp .env.example .env` and copy your Clerk API keys from the [**API keys**](https://dashboard.clerk.com/~/api-keys) page in the Clerk Dashboard into the `.env` file.
-- Run `pnpm start` to start the server.
+- Run `pnpm run dev` to start the server.
 - You should be able to connect to it now from any client that supports the latest version of the MCP spec. A cursor configuration is provided as a test.
 
 ### Connecting to the server

--- a/package.json
+++ b/package.json
@@ -2,11 +2,10 @@
   "name": "mcp-clerk-express",
   "version": "0.2.1",
   "description": "A demo MCP server using Clerk and Express",
-  "main": "index.js",
   "type": "module",
   "scripts": {
     "start": "vite-node index.ts",
-    "dev": "vite-node --watch index.ts"
+    "dev": "node --watch index.ts"
   },
   "author": "Jeff Escalante",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "start": "vite-node index.ts"
+    "start": "vite-node index.ts",
+    "dev": "vite-node --watch index.ts"
   },
   "author": "Jeff Escalante",
   "license": "MIT",


### PR DESCRIPTION
Adds a `dev` script that runs the server in watch mode. This gives a smoother local development experience where changes are picked up automatically without manually restarting, which is important when iterating on the MCP server so the endpoint reloads and stays working as you make changes.

## Changes

- Add `dev` script to `package.json` (`vite-node --watch index.ts`), keeping the existing `start` script for one-off runs
- Update the README setup steps to recommend `pnpm run dev` instead of `pnpm start`