### PR TITLE
Document and enforce Node >=22.18 requirement

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A minimal example of an MCP server endpoint using Express and Clerk for authenti
 
 ### Getting started
 
+- Make sure you're running Node.js `>= 22.18` — the dev script runs TypeScript directly using Node's type stripping.
 - Run `pnpm i` to install dependencies.
 - Create a Clerk application, then toggle on the **Dynamic client registration** option in the [**OAuth applications**](https://dashboard.clerk.com/~/oauth-applications) page in the Clerk Dashboard.
 - Run `cp .env.example .env` and copy your Clerk API keys from the [**API keys**](https://dashboard.clerk.com/~/api-keys) page in the Clerk Dashboard into the `.env` file.

--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
     "typescript": "^6.0.3",
     "vite-node": "^6.0.0"
   },
+  "engines": {
+    "node": ">=22.18"
+  },
   "packageManager": "pnpm@10.33.4+sha512.1c67b3b359b2d408119ba1ed289f34b8fc3c6873412bec6fd264fbdc82489e510fcbecb9ce9d22dae7f3b76269d8441046014bdca53b9979cd7a561ad631b800"
 }


### PR DESCRIPTION
## Summary

Follow-up to #7. The `dev` script now runs TypeScript directly via Node's type stripping, which requires Node >= 22.18 — on older Node it fails with a confusing syntax error at runtime. This makes the requirement visible and enforced at install time instead. (This commit was originally pushed to the #7 branch, but landed after the merge, so it's re-submitted here.)

## Changes

- Add `"engines": { "node": ">=22.18" }` to `package.json`
- Add `.npmrc` with `engine-strict=true` so `pnpm install` on an incompatible Node fails with a clear `ERR_PNPM_UNSUPPORTED_ENGINE` (verified: incompatible Node hard-fails, compatible installs stay clean with no warnings)
- Add a Node version note as the first Getting started step in the README

## References

- https://github.com/clerk/mcp-express-example/pull/7
